### PR TITLE
Add missing charset meta element for quotes to show correctly

### DIFF
--- a/private-plugins/templates-1.md
+++ b/private-plugins/templates-1.md
@@ -19,6 +19,7 @@ Create an HTML file with our plugins CSS embedded in the `<head>`.
 <!DOCTYPE html>
 <html>
   <head>
+    <meta charset="UTF-8">
     <link rel="stylesheet" href="https://usetrmnl.com/css/latest/plugins.css">
   </head>
   <body class="environment trmnl">


### PR DESCRIPTION
Looks like this on my machine, in the inbuilt browser in webstorm

Specifying charset fixes it

![image](https://github.com/user-attachments/assets/6ab4094e-6745-48bb-be1a-9f20ec7d4f9a)
